### PR TITLE
add argument for memory leak check on WSL

### DIFF
--- a/docs/08-dynamic-memory-allocation/README.md
+++ b/docs/08-dynamic-memory-allocation/README.md
@@ -597,6 +597,7 @@ Note that when the main function terminates (closing curly brace is reached), th
 A good tool to check for memory leaks and many other bugs is `valgrind`. While this is a pure Linux tool, it can be used on the `Windows Subsystem for Linux`.
 
 Just start valgrind and point it to your binary by executing the command as follows: `valgrind -s <binary>`.
+(On the Windows Subsystem for Linux use: `valgrind --leak-check=yes <binary>`)
 
 ::: codeoutput
 <pre>


### PR DESCRIPTION
The '-s' argument apparently doesn't exist for Valgrind when i installed it on my WSL.
However there is an argument that i think does the same thing: '--leak-check=yes'.